### PR TITLE
Removed `#[repr(C)]`

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -6,7 +6,6 @@ pub(crate) mod yaml;
 
 use crate::error;
 
-#[repr(C)]
 pub enum Ext {
     Json,
     Yaml,


### PR DESCRIPTION
jyt no longer provides C API.