### PR TITLE
Allow input from filename on the commandline

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,38 @@ $ echo $?
 0
 ```
 
+### Various Input Methods
+
+#### Input from `stdin`
+
+Typing at the terminal (terminate with Ctrl-D)
+
+```bash
+$ jyt jy
+```
+
+#### Input from file
+
+```bash
+$ cat file | jyt jy
+$ jyt jy < file
+$ jyt jy file
+```
+
+#### Input on commandline
+
+```bash
+$ jyt jy '{"name": "John", "age": 23}'
+```
+
+### Output
+
+Output always goes to `stdout`, and can be routed to a file like:
+
+```bash
+$ jyt jy inputfile > file
+```
+
 ## Contribution
 
 ### Build

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,12 @@ fn input_from_stdin() -> String {
 
 fn extract_input(input: &Option<String>) -> String {
     if let Some(input) = input {
-        input.clone()
+        let path = std::path::Path::new(input);
+        if path.exists() {
+            std::fs::read_to_string(input).unwrap()
+        } else {
+            input.clone()
+        }
     } else {
         input_from_stdin()
     }


### PR DESCRIPTION
The `jyt -h` help text nor the `README.md` is very clear on any commandline arguments other than the 6 basic commands (plus aliases). If someone would try to give a filename, it would return a cryptic error: `Error: Deserialization("expected value at line 1 column 1")` (and maybe wonder what is wrong with the content of the file).

This patch checks whether the argument is an existing filename, and if so, uses the content of that filename as input.

I added some clarification to the `README.md` that you might or might not like to accept.